### PR TITLE
fix: add missing jar manifest

### DIFF
--- a/MANIFEST.MF
+++ b/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: unluac.Main
+


### PR DESCRIPTION
  ## Summary

  The manifest declares `unluac.Main` as the jar entrypoint, allowing the documented `jar cfm ...` command to produce a runnable `java -jar unluac.jar` artifact.
  Built and ran the jar using the JDK tooling modules:

fixes #8 

  ```bash
  java -m jdk.compiler/com.sun.tools.javac.Main -d /tmp/unluac-verify-codex/build unluac/Main.java
  java -m jdk.jartool/sun.tools.jar.Main cfm /tmp/unluac-verify-codex/unluac.jar /home/slayer/lua/unluac/MANIFEST.MF unluac/
  java -jar /tmp/unluac-verify-codex/unluac.jar --version
